### PR TITLE
issue-#12 project data not deleted from ShareDB + hotfixes

### DIFF
--- a/app/views/project_settings.ejs
+++ b/app/views/project_settings.ejs
@@ -148,6 +148,12 @@
         <% } %>
     </div>
 
+    <% if (ptitle) { %>
+        <script>
+            ptitle = "<%= unescape(ptitle) %>";
+        </script>
+    <% } %>
+
     <!-- jQuery Libraries -->
     <script type="text/javascript" src="/dist/js/jquery-latest.js"></script>
 

--- a/config.js
+++ b/config.js
@@ -12,9 +12,12 @@ module.exports = {
     database: {
         hostname: 'localhost',
         port: 27017,
-        name: 'simutex'
+        name: 'simutex',
+        project: {
+            delete: 'archive'
+        }
     },
     latexmk: {
-        path: 'X:/SimuTex/latexmk'
+        path: 'X:/simutex-fork/latexmk'
     }
 }

--- a/frontend/js/editor.js
+++ b/frontend/js/editor.js
@@ -165,6 +165,7 @@ doc.subscribe(function (err) {
     if (err) throw err;
     aceEditorLeft.setValue(doc.data);
     aceEditorLeft.moveCursorTo(0, 0);
+    compileLaTeX(true);
     aceEditorLeft.on('change', (delta) => {
         if (!suppressed) {
             const aceDoc = aceEditorLeft.getSession().getDocument();

--- a/frontend/public/dist/js/project-settings.js
+++ b/frontend/public/dist/js/project-settings.js
@@ -9,7 +9,9 @@ $(() => {
 });
 
 function attemptDelete() {
-    if ($("#delete_project_title").val().trim().toLowerCase() == "<%= unescape(ptitle).trim().toLowerCase() %>") {
+    console.log($("#delete_project_title").val().trim().toLowerCase());
+    console.log("<%= unescape(ptitle).trim().toLowerCase() %>");
+    if ($("#delete_project_title").val().trim().toLowerCase() == ptitle.trim().toLowerCase()) {
         window.location.href = './delete';
     }
 }


### PR DESCRIPTION
Project data is deleted from the ShareDB collections based on config.database.project.delete parameters.

Value: description
all: deletes all information from `projects`, `project_data` and, `o_project_data`, and the hard-disk
hidden: retains all information (including version history) but hides the project from access
archive: removes all version history but retains the document data, hides it from all users

Additionally adds a patch that prevented projects from being deleted at all.