### PR TITLE
Authentication changes + ShareDB auth

### DIFF
--- a/app.js
+++ b/app.js
@@ -73,7 +73,7 @@ app.get('/login', (req, res) => {
  * 
  * Redirects to /projects if authentication is successful.
  */
-app.post('/login', auth.credentials, (req, res) => {
+app.post('/login', auth.middleware.credentials, (req, res) => {
     res.redirect('/projects');
 });
 
@@ -97,7 +97,7 @@ app.get('/test', (req, res) => {
     });
 });
 
-app.get('/admin', auth.credentials, auth.admin, (req, res) => {
+app.get('/admin', auth.middleware.credentials, auth.middleware.admin, (req, res) => {
     ejs.renderFile('./app/views/admin.ejs', {}, {}, (err, str) => {
         res.send(str);
     });

--- a/app.js
+++ b/app.js
@@ -1,12 +1,13 @@
 const express = require('express');
 const bodyParser = require("body-parser");
-const cookierParser = require("cookie-parser");
+const cookieParser = require("cookie-parser");
 const ejs = require('ejs');
 const app = express();
 app.use(express.static(__dirname + '/frontend/public'))
 app.use(bodyParser.urlencoded({ extended: true }));
 app.use(bodyParser.json());
-app.use(cookierParser());
+app.use(cookieParser());
+const ews = require('express-ws')(app);
 
 const config = require('./config');
 const auth = require('./app/src/auth');
@@ -96,12 +97,19 @@ app.get('/test', (req, res) => {
     });
 });
 
+app.get('/admin', auth.credentials, auth.admin, (req, res) => {
+    ejs.renderFile('./app/views/admin.ejs', {}, {}, (err, str) => {
+        res.send(str);
+    });
+});
+
+
 /**
  * Start the application on the specified port.
  */
-var server = app.listen(config.server.port, () => {
+app.listen(config.server.port, () => {
     console.log(`Server listening on the port::${config.server.port}`);
 
     // Create the ShareDB WebSocket 
-    projectsRoute.createCollaborationServer(server);
+    projectsRoute.createCollaborationServer(app);
 });

--- a/app/src/auth.js
+++ b/app/src/auth.js
@@ -2,6 +2,23 @@ const db = require('./db');
 const crypto = require('crypto');
 
 /**
+ * User credential authentication.
+ * 
+ * Executes pass() if the username and hashword are valid.
+ * Executes fail() if they are not.
+ */
+function authCredentials(username, hashword, pass, fail) {
+    db.get().collection('accounts').find({ username: username, password: hashword }).toArray((err, accounts) => {
+        if (err || accounts.length != 1) {
+            fail();
+        }
+        if (accounts.length == 1) {
+            pass();
+        }
+    });
+}
+
+/**
  * Credential authentication middleware.
  * 
  * Attempts to authenticate the user credentials.
@@ -12,34 +29,22 @@ const crypto = require('crypto');
  * 
  * @param {function} fail Optional function fired when authentication is unscuccessful.
  */
-function authCredentials(req, res, next, fail = undefined) {
+function authCredentialsMiddleware(req, res, next, fail = undefined) {
     if (req.body.username === undefined || req.body.password === undefined) {
         if (req.cookies.u !== undefined && req.cookies.h !== undefined) {
-            db.get().collection('accounts').find({ username: req.cookies.u, password: req.cookies.h }).toArray((err, accounts) => {
-                if (err || accounts.length != 1) {
-                    defaultLoginFail(req, res, fail);
-                }
-                if (accounts.length == 1) {
-                    next();
-                }
-            });
+            authCredentials(req.cookies.u, req.cookies.h, next, () => { defaultLoginFail(req, res, fail) });
         } else {
             defaultLoginFail(req, res, fail);
         }
     } else {
         var hashpass = crypto.createHash("sha512").update(req.body.password, 'utf-8').digest('hex');
-        db.get().collection('accounts').find({ username: req.body.username, password: hashpass }).toArray((err, accounts) => {
-            if (err || accounts.length != 1) {
-                defaultLoginFail(req, res, fail);
+        authCredentials(req.cookies.u, req.cookies.h, () => {
+            if (req.cookies.username === undefined) {
+                res.cookie('u', req.body.username, { maxAge: 7 * 24 * 60 * 60 * 1000 })
+                res.cookie('h', hashpass, { maxAge: 7 * 24 * 60 * 60 * 1000 })
             }
-            if (accounts.length == 1) {
-                if (req.cookies.username === undefined) {
-                    res.cookie('u', req.body.username, { maxAge: 7 * 24 * 60 * 60 * 1000 })
-                    res.cookie('h', hashpass, { maxAge: 7 * 24 * 60 * 60 * 1000 })
-                }
-                next();
-            }
-        });
+            next();
+        }, () => { defaultLoginFail(req, res, fail) });
     }
 }
 
@@ -59,17 +64,44 @@ function defaultLoginFail(req, res, fail) {
 }
 
 /**
- * Attempts to authenticate if a user can modify the specified project.
+ * Project modification authentication.
+ * 
+ * Executes pass() if the user can modify the project.
+ * Executes fail() if they cannot.
+ */
+function authProjectModify(id, username, pass, fail) {
+    db.get().collection('projects').find({ id: id, $or: [{ owner: username }, { collaborators: { $in: [username] } }] }).toArray((err, project) => {
+        if (err || project.length != 1) {
+            fail();
+        }
+        if (project.length == 1) {
+            pass();
+        }
+    });
+}
+
+/**
+ * Project modification middleware authentication.
  * 
  * Users who can modify a project are the owner and collaborators.
  */
-function authProjectModify(req, res, next, fail = undefined) {
-    db.get().collection('projects').find({ id: req.params.id, $or: [{ owner: req.cookies.u }, { collaborators: { $in: [req.cookies.u] } }] }).toArray((err, project) => {
+function authProjectModifyMiddleware(req, res, next, fail = undefined) {
+    authProjectModify(req.params.id, req.cookies.u, next, () => { defaultProjectFail(req, res, fail) });
+}
+
+/**
+ * Project owner authentication.
+ * 
+ * Executes pass() if the user owns the project.
+ * Executes fail() if they do not.
+ */
+function authProjectOwner(id, username, pass, fail) {
+    db.get().collection('projects').find({ id: id, owner: username }).toArray((err, project) => {
         if (err || project.length != 1) {
-            defaultProjectFail(req, res, fail);
+            fail();
         }
         if (project.length == 1) {
-            next();
+            pass();
         }
     });
 }
@@ -77,13 +109,23 @@ function authProjectModify(req, res, next, fail = undefined) {
 /**
  * Attempts to authenticate if the user is the project owner.
  */
-function authProjectOwner(req, res, next, fail = undefined) {
-    db.get().collection('projects').find({ id: req.params.id, owner: req.cookies.u }).toArray((err, project) => {
+function authProjectOwnerMiddleware(req, res, next, fail = undefined) {
+    authProjectOwner(req.params.id, req.cookies.u, next, () => { defaultProjectFail(req, res, fail) });
+}
+
+/**
+ * Project access authentication.
+ * 
+ * Executes pass() if the user can access the project.
+ * Executes fail() if they cannot.
+ */
+function authProjectAccess(id, username, pass, fail) {
+    db.get().collection('projects').find({ id: id, $or: [{ owner: { $in: [username] } }, { collaborators: { $in: [username] } }, { viewers: { $in: [username] } }] }).toArray((err, project) => {
         if (err || project.length != 1) {
-            defaultProjectFail(req, res, fail);
+            fail();
         }
         if (project.length == 1) {
-            next();
+            pass();
         }
     });
 }
@@ -93,15 +135,8 @@ function authProjectOwner(req, res, next, fail = undefined) {
  * 
  * Users who can access the project are the owner, collaborators, and viewers.
  */
-function authProjectAccess(req, res, next, fail = undefined) {
-    db.get().collection('projects').find({ id: req.params.id, $or: [{ owner: { $in: [req.cookies.u] } }, { collaborators: { $in: [req.cookies.u] } }, { viewers: { $in: [req.cookies.u] } }] }).toArray((err, project) => {
-        if (err || project.length != 1) {
-            defaultProjectFail(req, res, fail);
-        }
-        if (project.length == 1) {
-            next();
-        }
-    });
+function authProjectAccessMiddleware(req, res, next, fail = undefined) {
+    authProjectAccess(req.params.id, req.cookies.u, next, () => { defaultProjectFail(req, res, fail) });
 }
 
 /**
@@ -120,7 +155,7 @@ function defaultProjectFail(req, res, fail) {
  * 
  * Redirects the user to their previous back if a failure callback is not provided.
  */
-function authAdministrator(req, res, next, fail = undefined) {
+function authAdministratorMiddleware(req, res, next, fail = undefined) {
     db.get().collection('accounts').find({ username: req.cookies.u, admin: true }).toArray((err, account) => {
         if (err || account.length != 1) {
             if (fail === undefined) {
@@ -141,5 +176,13 @@ module.exports = {
         owner: authProjectOwner,
         access: authProjectAccess
     },
-    admin: authAdministrator 
+    middleware: {
+        credentials: authCredentialsMiddleware,
+        admin: authAdministratorMiddleware,
+        project: {
+            modify: authProjectModifyMiddleware,
+            owner: authProjectOwnerMiddleware,
+            access: authProjectAccessMiddleware
+        }
+    }
 }

--- a/app/src/projects.js
+++ b/app/src/projects.js
@@ -7,10 +7,8 @@ const bodyParser = require('body-parser');
 const cookierParser = require('cookie-parser');
 const spawn = require('child_process').spawn;
 const uuid = require('uuid');
-const WebSocket = require('ws');
 const ShareDB = require('sharedb');
 const WebSocketJSONStream = require('@teamwork/websocket-json-stream');
-const url = require('url');
 
 const cmdRouter = express.Router({ mergeParams: true });
 cmdRouter.use(bodyParser.urlencoded({ extended: true }));

--- a/app/src/projects.js
+++ b/app/src/projects.js
@@ -29,15 +29,18 @@ const backend = new ShareDB({ db: sdb });
  * Use express-ws for WebSocket connection using `ws` underneath
  */
 function createCollaborationServer(app) {
-    app.ws('/', (ws, req) => {
-        auth.credentials(req, null, () => {
-            let metadata = {
-                userid: req.cookies.u
-            }
-            let stream = new WebSocketJSONStream(ws);
-            backend.listen(stream, metadata);
-        }, undefined);
-    })
+    app.ws('/api/:id', (ws, req) => {
+        console.log(req.params);
+        auth.credentials(req.cookies.u, req.cookies.h, () => {
+            auth.project.modify(req.params.id, req.cookies.u, () => {
+                let metadata = {
+                    userid: req.cookies.u
+                }
+                let stream = new WebSocketJSONStream(ws);
+                backend.listen(stream, metadata);
+            }, () => { })
+        }, () => { });
+    });
 }
 
 /** 
@@ -60,11 +63,10 @@ backend.use('submit', (request, callback) => {
     callback();
 });
 
-
 /**
  * Require credential authentication for all requests.
  */
-router.use(auth.credentials);
+router.use(auth.middleware.credentials);
 
 /**
  * Show a list of all the users projects.
@@ -110,17 +112,17 @@ router.get('/new', (req, res) => {
 /**
  * Create a new router that accepts a UUIDv4 parameters called "id" which represents the document unique ID.
  */
-router.use('/:id([0-9A-F]{8}-[0-9A-F]{4}-4[0-9A-F]{3}-[89AB][0-9A-F]{3}-[0-9A-F]{12})', auth.project.access, cmdRouter);  // uuidv4 regex (8-4-4-4-12)
+router.use('/:id([0-9A-F]{8}-[0-9A-F]{4}-4[0-9A-F]{3}-[89AB][0-9A-F]{3}-[0-9A-F]{12})', auth.middleware.project.access, cmdRouter);  // uuidv4 regex (8-4-4-4-12)
 
 /**
  * Determine whether they route to /edit or /view based on their project permissions
  * Uses callback functions for failure
  */
 cmdRouter.get('/', (req, res) => {
-    auth.project.modify(req, res, () => {
+    auth.middleware.project.modify(req, res, () => {
         res.redirect(`/projects/${req.params.id}/edit`);
     }, () => {
-        auth.project.access(req, res, () => {
+        auth.middleware.project.access(req, res, () => {
             res.redirect(`/projects/${req.params.id}/view`);
         }, () => {
             res.redirect('/projects');
@@ -135,7 +137,7 @@ cmdRouter.get('/', (req, res) => {
  * If the user does not have access permissions, then they will be routed to their projects.
  */
 cmdRouter.get('/edit', (req, res) => {
-    auth.project.modify(req, res, () => {
+    auth.middleware.project.modify(req, res, () => {
         // Get project data
         db.get().collection('projects').findOne({ id: req.params.id }, { projection: { title: true, owner: true, collaborators: true, viewers: true } }, (err, project) => {
             if (err) throw err;
@@ -169,7 +171,7 @@ cmdRouter.get('/edit', (req, res) => {
             });
         });
     }, () => {
-        auth.project.access(req, res, () => {
+        auth.middleware.project.access(req, res, () => {
             res.redirect(`/projects/${req.params.id}/view`);
         }, () => {
             res.redirect('/projects');
@@ -180,14 +182,14 @@ cmdRouter.get('/edit', (req, res) => {
 /**
  * Send the PDF document to the browser for rendering.
  */
-cmdRouter.get('/view', auth.project.access, (req, res) => {
+cmdRouter.get('/view', auth.middleware.project.access, (req, res) => {
     res.sendFile(req.params.id + '/out.pdf', { root: 'projects' });
 });
 
 /**
  * Alias for /view
  */
-cmdRouter.get('/pdf', auth.project.access, (req, res) => {
+cmdRouter.get('/pdf', auth.middleware.project.access, (req, res) => {
     res.redirect(`/projects/${req.params.id}/view`);
 });
 
@@ -197,7 +199,7 @@ cmdRouter.get('/pdf', auth.project.access, (req, res) => {
  * Returned page body does not contain any text/data other than the document.
  * Formatting may not appear as shown in the editor.
  */
-cmdRouter.get('/raw', auth.project.access, (req, res) => {
+cmdRouter.get('/raw', auth.middleware.project.access, (req, res) => {
     res.set('Content-Type', 'text/html');
     res.send(fs.readFileSync(`./projects/${req.params.id}/in.tex`).toString());
 });
@@ -207,7 +209,7 @@ cmdRouter.get('/raw', auth.project.access, (req, res) => {
  * 
  * Formatting should be identical, with the exception of tab length, to the editor. 
  */
-cmdRouter.get('/text', auth.project.access, (req, res) => {
+cmdRouter.get('/text', auth.middleware.project.access, (req, res) => {
     res.set('Content-Type', 'text/html');
     res.send('<html><body><pre>' + fs.readFileSync(`./projects/${req.params.id}/in.tex`).toString() + '</pre></body></html>');
 });
@@ -217,7 +219,7 @@ cmdRouter.get('/text', auth.project.access, (req, res) => {
  * 
  * Sends a basic messages if the output PDF does not exist.
  */
-cmdRouter.get('/download', auth.project.access, (req, res) => {
+cmdRouter.get('/download', auth.middleware.project.access, (req, res) => {
     var file = `./projects/${req.params.id}/out.pdf`;
     if (fs.existsSync(file)) {
         res.download(file);
@@ -231,9 +233,7 @@ cmdRouter.get('/download', auth.project.access, (req, res) => {
  * 
  * Requires owner permissions.
  */
-cmdRouter.get('/delete', auth.project.owner, (req, res) => {
-
-
+cmdRouter.get('/delete', auth.middleware.project.owner, (req, res) => {
     switch (config.database.project.delete) {
         case 'all':
             // Delete all data from `projects`, `project_data`, and `o_project_data` and on-disk    
@@ -269,7 +269,7 @@ cmdRouter.get('/delete', auth.project.owner, (req, res) => {
 /**
  * Shows project settings.
  */
-cmdRouter.get('/settings', auth.project.modify, (req, res) => {
+cmdRouter.get('/settings', auth.middleware.project.modify, (req, res) => {
     db.get().collection('projects').findOne({ id: req.params.id }, { projection: { title: true, owner: true, collaborators: true, viewers: true } }, (err, project) => {
         fs.readFile(`./projects/${req.params.id}/in.tex`, (err, data) => {
             ejs_vars = {
@@ -296,7 +296,7 @@ cmdRouter.get('/settings', auth.project.modify, (req, res) => {
 /**
  * Shows project settings, passing an action as a JavaScript variable for local use.
  */
-/* cmdRouter.get('/settings/:action', auth.project.modify, (req, res) => {
+/* cmdRouter.get('/settings/:action', auth.middleware.project.modify, (req, res) => {
     db.get().collection('projects').findOne({ id: req.params.id }, { projection: { title: true, owner: true, collaborators: true } }, (err, project) => {
         fs.readFile(`./projects/${req.params.id}/in.tex`, (err, data) => {
             ejs_vars = {
@@ -318,7 +318,7 @@ cmdRouter.get('/settings', auth.project.modify, (req, res) => {
 /**
  * Attempts to rename the project.
  */
-cmdRouter.post('/settings/rename', auth.project.modify, (req, res) => {
+cmdRouter.post('/settings/rename', auth.middleware.project.modify, (req, res) => {
     if (req.body.data) {
         db.get().collection('projects').updateOne({ id: req.params.id }, { $set: { title: req.body.data } }, (err, project) => {
             if (err) {
@@ -333,7 +333,7 @@ cmdRouter.post('/settings/rename', auth.project.modify, (req, res) => {
 /**
  * Removes a collaborator or viewer from the project.
  */
-cmdRouter.post('/settings/removeuser', auth.project.modify, (req, res) => {
+cmdRouter.post('/settings/removeuser', auth.middleware.project.modify, (req, res) => {
     function handle(err, project) {
         if (err) {
             res.send('E');
@@ -353,7 +353,7 @@ cmdRouter.post('/settings/removeuser', auth.project.modify, (req, res) => {
 /**
  * Adds a collaborator or viewer from the project.
  */
-cmdRouter.post('/settings/adduser', auth.project.modify, (req, res) => {
+cmdRouter.post('/settings/adduser', auth.middleware.project.modify, (req, res) => {
     function handle(err, project) {
         if (err) {
             res.send('E');
@@ -377,7 +377,7 @@ cmdRouter.post('/settings/adduser', auth.project.modify, (req, res) => {
  * Returns base64 encoded PDF data.
  * Builds the document and returns it if specified in the post data. (build = true)
  */
-cmdRouter.post('/build', auth.project.modify, (req, res) => {
+cmdRouter.post('/build', auth.middleware.project.modify, (req, res) => {
     let build_dir = 'projects/' + req.params.id;
     mkdirp(build_dir).then(made => {
         let in_file = build_dir + '/in.tex'

--- a/frontend/js/editor.js
+++ b/frontend/js/editor.js
@@ -140,7 +140,7 @@ window['process'] = process;
 import * as json1 from 'ot-json1';
 
 sharedb.types.register(json1.type);
-var socket = new ReconnectingWebSocket('ws://' + window.location.hostname + ':3080');
+var socket = new ReconnectingWebSocket('ws://' + window.location.hostname + ':3080/api/' + pid);
 var connection = new sharedb.Connection(socket);
 
 socket.addEventListener('open', function () {

--- a/package-lock.json
+++ b/package-lock.json
@@ -369,6 +369,11 @@
       "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
       "integrity": "sha1-rqdNXmHB+JlhO/ZL2mbUx48v0X0="
     },
+    "async-limiter": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.1.tgz",
+      "integrity": "sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ=="
+    },
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
@@ -958,6 +963,24 @@
         "type-is": "~1.6.18",
         "utils-merge": "1.0.1",
         "vary": "~1.1.2"
+      }
+    },
+    "express-ws": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/express-ws/-/express-ws-4.0.0.tgz",
+      "integrity": "sha512-KEyUw8AwRET2iFjFsI1EJQrJ/fHeGiJtgpYgEWG3yDv4l/To/m3a2GaYfeGyB3lsWdvbesjF5XCMx+SVBgAAYw==",
+      "requires": {
+        "ws": "^5.2.0"
+      },
+      "dependencies": {
+        "ws": {
+          "version": "5.2.2",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-5.2.2.tgz",
+          "integrity": "sha512-jaHFD6PFv6UgoIVda6qZllptQsMlDEJkTQcybzzXDYM1XO9Y8em691FGMPmM46WGyLU4z9KMgQN+qrux/nhlHA==",
+          "requires": {
+            "async-limiter": "~1.0.0"
+          }
+        }
       }
     },
     "fast-deep-equal": {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
         "cookie-parser": "^1.4.5",
         "ejs": "^3.1.5",
         "express": "^4.17.1",
+        "express-ws": "^4.0.0",
         "fs": "0.0.1-security",
         "mkdirp": "^1.0.4",
         "mongo-sanitize": "^1.1.0",


### PR DESCRIPTION
This PR changes how credential authentication is exposed internally.

All authentication methods are now broken down into two distinct methods. The first method provides a way to execute a pass or fail parameter based on the authentication results. The second method is an ExpressJS middleware wrapper to utilize these authentication checks.

Prior to this PR internal authentication checks were not possible.

ShareDB uses WebSockets to perform operational transformations. This PR additionally now attaches the users verified username to all operations they perform. The user cannot connect to the ShareDB service without verifying 1. they are logged in, and 2. they are able to modify the project thanks to the now exposed internal authentication checks.