### PR TITLE
efficient project/client websocket cleanup

### DIFF
--- a/app.js
+++ b/app.js
@@ -110,6 +110,9 @@ app.listen(config.server.port, () => {
     console.log(`Server listening on the port::${config.server.port}`);
 });
 
+/**
+ * Provide the backend WebSocket hook to ShareDB for collaborative editing.
+ */
 app.ws('/api/:id', (ws, req) => {
     auth.credentials(req.cookies.u, req.cookies.h, () => {
         auth.project.modify(req.params.id, req.cookies.u, () => {
@@ -122,21 +125,49 @@ app.ws('/api/:id', (ws, req) => {
     }, () => { });
 });
 
+/**
+ * Handle extra communication for projects, such as cursor position and selection.
+ * 
+ * liveProjectCleanup periodically checks all WebSocket connections for a specific project and discords project references for closed projects.
+ */
+let live_projects = {};
+
+function liveProjectCleanup() {
+    setTimeout(() => {
+        for (let project in live_projects) {
+            for (let wsi = 0; wsi < live_projects[project].length; wsi++) {
+                if (live_projects[project][wsi].readyState === 2 || live_projects[project][wsi].readyState === 3) {  // 2 === ws.CLOSING, 3 === ws.CLOSED
+                    live_projects[project].splice(wsi, 1);
+                }
+            }
+            if (live_projects[project].length == 0) {
+                delete live_projects[project];
+            }
+        }
+        liveProjectCleanup();
+    }, 2500);
+}
+liveProjectCleanup();
+
 app.ws('/api/extras/:id', (ws, req) => {
     auth.credentials(req.cookies.u, req.cookies.h, () => {
         auth.project.modify(req.params.id, req.cookies.u, () => {
+            if (!(req.params.id in live_projects)) {
+                live_projects[req.params.id] = [ws];
+            } else {
+                live_projects[req.params.id].push(ws);
+            }
             ws.project = req.params.id
             ws.on('message', (msg) => {
-                ews.getWss().clients.forEach((client) => {
-                    if (client !== ws && client.project == req.params.id) {
-                        if (client.readyState === ws.OPEN) {
-                            let data = JSON.parse(msg);
-                            data.username = req.cookies.u;
-                            client.send(JSON.stringify(data));
-                        }
+                for (let clientIndex = 0; clientIndex < live_projects[ws.project].length; clientIndex++) {
+                    let client = live_projects[ws.project][clientIndex];
+                    if (client !== ws && client.readyState == ws.OPEN) {
+                        let data = JSON.parse(msg);
+                        data.username = req.cookies.u;
+                        client.send(JSON.stringify(data));
                     }
-                });
+                }
             });
-        }, () => { })
-    }, () => { });
+        }, () => { }); // don't register the websocket if they cannot modify the project
+    }, () => { }); // don't check project access if their credentials are invalid
 })

--- a/frontend/js/editor/SocketManager.js
+++ b/frontend/js/editor/SocketManager.js
@@ -36,7 +36,7 @@ doc.subscribe(function (err) {
     aceEditorLeft.moveCursorTo(0, 0);
 
     var manager = new AceCursorManager(aceEditorLeft.getSession());
-    var sock2 = new WebSocket('ws://' + window.location.hostname + ':3080/api/extras/' + pid);
+    var sock2 = new ReconnectingWebSocket('ws://' + window.location.hostname + ':3080/api/extras/' + pid);
 
     let colors = ["#f44336", "#e91e63", "#9c27b0", "#3f51b5", "#673ab7", "#009688", "#ff5722", "#4caf50", "#9a0036"];
 


### PR DESCRIPTION
Previous implementation required every message to parse over every connect client to check if their project was the same as the sender. This implementation scales exponentially as the number of users increase.

The new implementation stores projects in a dictionary and a reference to all corresponding clients within. Periodically (currently configured as 2.5 sec) the dictionary is iterated over to remove closing/closed clients, and projects who do not have any connected clients.