### PR TITLE
#53 Map document ID to project ID

### DIFF
--- a/app/views/editor.ejs
+++ b/app/views/editor.ejs
@@ -92,6 +92,7 @@
         var pid = unescape(`<%= pid %>`);
         var pdata = unescape(`<%= pdata %>`);
         var puser = unescape(`<%= puser %>`);
+        var documents = unescape(`<%= documents %>`).split(',');
         var bname = '<%= brand.name %>';
     </script>
     <% } %>

--- a/config.js
+++ b/config.js
@@ -14,7 +14,7 @@ module.exports = {
         port: 27017,
         name: 'simutex',
         project: {
-            delete: 'archive'
+            delete: 'all'
         }
     }
 }

--- a/frontend/js/editor/SocketManager.js
+++ b/frontend/js/editor/SocketManager.js
@@ -23,11 +23,10 @@ socket.addEventListener('error', function () {
     console.log('Error');
 });
 
-var doc = connection.get('project_data', pid);
-
 var path = [];
 var suppressed = false;
 var my_id = puser;
+var doc = connection.get('project_data', documents[0]);
 
 doc.subscribe(function (err) {
     if (err) throw err;
@@ -90,6 +89,8 @@ doc.subscribe(function (err) {
                 }
             } else if (element.action == 'viewUpdate') {
                 ViewerManager.setViewer(element.data);
+            } else if (element.action == 'documentUpdate') {
+                // handle updating the front-end HTML for which files are present for the project
             }
         });
     };

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -2,6 +2,7 @@ const path = require('path');
 const webpack = require('webpack');
 
 module.exports = {
+    mode: 'development',
     entry: {
         editor: path.resolve(__dirname, 'frontend', 'js', 'editor', 'index.js')
     },


### PR DESCRIPTION
A project entry in the MongoDB now has a key called `documents` which contains the associated document IDs. There is also a key `main` which is the document ID of the main TeX file, whose name shall always be `main.tex`. The first entry in the documents key is always the ID of the main document. Additional document IDs in the `documents` key are additional associated TeX files.

Since this project is also in development, the `development` mode for WebPack was assigned to reduce build time. The default project deletion method was also set to `all` instead of `archive`.